### PR TITLE
Revert "core: config: no sepolicy for now"

### DIFF
--- a/core/config.mk
+++ b/core/config.mk
@@ -1094,11 +1094,11 @@ include $(BUILD_SYSTEM)/ninja_config.mk
 include $(BUILD_SYSTEM)/soong_config.mk
 endif
 
-#ifneq ($(AOSIP_BUILD),)
+ifneq ($(AOSIP_BUILD),)
 ## We need to be sure the global selinux policies are included
 ## last, to avoid accidental resetting by device configs
-#$(eval include device/aosip/sepolicy/common/sepolicy.mk)
-#endif
+$(eval include device/aosip/sepolicy/common/sepolicy.mk)
+endif
 
 # Include any vendor specific config.mk file
 -include vendor/*/build/core/config.mk


### PR DESCRIPTION
This reverts commit eae59c789e54c421671ca5b6fa4643d04b6d46ff.

Change-Id: I8b8d2e1dc8f346df8137670451cebba2fffc649f